### PR TITLE
fix: add SRI integrity hash to Font Awesome CDN link

### DIFF
--- a/src/lib/Resources.svelte
+++ b/src/lib/Resources.svelte
@@ -133,7 +133,7 @@
 </script>
 
 <svelte:head>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </svelte:head>
 
 


### PR DESCRIPTION
Corrige l'avertissement CodeQL "Inclusion of functionality from an untrusted source" en ajoutant l'attribut `integrity` (SRI), `crossorigin="anonymous"` et `referrerpolicy="no-referrer"` au lien CDN Font Awesome dans `Resources.svelte`.

Made with [Cursor](https://cursor.com)